### PR TITLE
fix(ci): update GitHub Actions release workflow permissions and action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - 'v*' # Trigger on version tags like v1.0.0, v1.2.3, etc.
 
+permissions:
+  contents: write
+  packages: write
+  actions: read
+  pull-requests: write
+  issues: write
+  repository-projects: write
+
 env:
   NODE_VERSION: '20'
   REGISTRY: docker.io
@@ -159,12 +167,9 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ steps.get_version.outputs.VERSION }}
+          name: Release ${{ steps.get_version.outputs.VERSION }}
           body: |
             ## Changes in v${{ steps.get_version.outputs.VERSION }}
             


### PR DESCRIPTION
## Summary
Fixes GitHub Actions release workflow by updating permissions and replacing deprecated action.

## Changes
- **Add comprehensive permissions** to resolve "Resource not accessible by integration" error:
  - `contents: write` - For creating releases
  - `packages: write` - For package operations
  - `pull-requests: write` - For PR operations
  - `issues: write` - For issue operations
  - `repository-projects: write` - For repository projects
  - `actions: read` - For reading workflow artifacts

- **Replace deprecated action**: 
  - From: `actions/create-release@v1` (deprecated)
  - To: `softprops/action-gh-release@v1` (actively maintained)

- **Update action parameters**:
  - Use `name` instead of `release_name`
  - Remove `tag_name` (handled automatically)
  - Remove explicit `GITHUB_TOKEN` env var (handled by action)

## Problem Solved
The release workflow was failing with "Resource not accessible by integration" error due to insufficient permissions and use of deprecated GitHub Actions.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test workflow with a new tag (e.g., `v1.0.3-test`)
- [ ] Confirm release is created successfully
- [ ] Verify NPM and Docker publishing still work

## Related
- GitHub Actions documentation: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
- softprops/action-gh-release: https://github.com/softprops/action-gh-release